### PR TITLE
Update .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,15 @@
+# Ignore standard Rust things
+/debug
 /target
+Cargo.lock
+
+# Ignore configuration files
+mntconfig.toml
+.env
+
+# Ignore databases
+*.sqlite
+
+# Ignore attachment directories
+/docstore
+/datev-export


### PR DESCRIPTION
Add lines to ignore Rust-specific, environment-specific, and application-specific files and directories.

This will allow a developer to follow the readme and not have to manually ignore a bunch of files and directories that get created.