### PR TITLE
Pull select options from config

### DIFF
--- a/src/routes/documents.rs
+++ b/src/routes/documents.rs
@@ -321,9 +321,16 @@ pub async fn new_document(
 
     invoice_payment_terms.sort();
 
+    let mut tax_rates: Vec<String> = config.tax_rates.iter()
+        .map(|kv| kv.0.to_string())
+        .collect();
+
+    tax_rates.sort();
+
     ctx.insert("document", &document);
     ctx.insert("line_items", &items);
     ctx.insert("invoice_payment_terms", &invoice_payment_terms);
+    ctx.insert("tax_rates", &tax_rates);
 
     let s = tmpl.render("document_new.html", &ctx)
         .map_err(|e| error::ErrorInternalServerError(format!("Template error: {:?}", e)))
@@ -357,9 +364,16 @@ pub async fn copy_document(
 
     invoice_payment_terms.sort();
 
+    let mut tax_rates: Vec<String> = config.tax_rates.iter()
+        .map(|kv| kv.0.to_string())
+        .collect();
+
+    tax_rates.sort();
+
     ctx.insert("document", &doc);
     ctx.insert("line_items", &documents::line_items(&result));
     ctx.insert("invoice_payment_terms", &invoice_payment_terms);
+    ctx.insert("tax_rates", &tax_rates);
 
     // TODO Make .kind selected in template somehow?
 

--- a/src/routes/documents.rs
+++ b/src/routes/documents.rs
@@ -271,7 +271,8 @@ pub async fn add_document_json(
 
 #[get("/documents/new")]
 pub async fn new_document(
-    tmpl: web::Data<tera::Tera>
+    tmpl: web::Data<tera::Tera>,
+    config: web::Data<Config>
 ) -> Result<HttpResponse, Error> {
     let mut ctx = tera::Context::new();
 
@@ -314,8 +315,15 @@ pub async fn new_document(
         amount_cents: 0
     }];
 
+    let mut invoice_payment_terms: Vec<String> = config.invoice_payment_terms.iter()
+        .map(|kv| kv.0.to_string())
+        .collect();
+
+    invoice_payment_terms.sort();
+
     ctx.insert("document", &document);
     ctx.insert("line_items", &items);
+    ctx.insert("invoice_payment_terms", &invoice_payment_terms);
 
     let s = tmpl.render("document_new.html", &ctx)
         .map_err(|e| error::ErrorInternalServerError(format!("Template error: {:?}", e)))
@@ -328,7 +336,8 @@ pub async fn new_document(
 pub async fn copy_document(
     tmpl: web::Data<tera::Tera>,
     pool: web::Data<DbPool>,
-    path: web::Path<(String,)>
+    path: web::Path<(String,)>,
+    config: web::Data<Config>
 ) -> Result<HttpResponse, Error> {
     let conn = pool.get().expect("couldn't get db connection from pool");
 
@@ -342,8 +351,15 @@ pub async fn copy_document(
         ..result.clone()
     };
 
+    let mut invoice_payment_terms: Vec<String> = config.invoice_payment_terms.iter()
+        .map(|kv| kv.0.to_string())
+        .collect();
+
+    invoice_payment_terms.sort();
+
     ctx.insert("document", &doc);
     ctx.insert("line_items", &documents::line_items(&result));
+    ctx.insert("invoice_payment_terms", &invoice_payment_terms);
 
     // TODO Make .kind selected in template somehow?
 

--- a/templates/document_new.html
+++ b/templates/document_new.html
@@ -35,9 +35,10 @@
         <label for="idate">Date:</label> <input type="text" id="idate" value="{{document.doc_date}}" onchange="recalc()"><br>
         <label for="ordernum">Order ID:</label> <input type="text" id="ordernum" onchange="recalc()"><br>
         <select id="payment-method" onchange="recalc()">
-          <option value="sepa" selected>SEPA</option>
-          <option value="paypal">paypal (paid)</option>
-          <option value="cash">cash (paid)</option>
+          <option value="" selected>Payment Method</option>
+          {% for term in invoice_payment_terms %}
+            <option value="{{term}}">{{term}}</option>
+          {% endfor %}
         </select>
         <select id="tax-code" onchange="recalc()">
           <option value="EU16" selected>EU 16%</option>

--- a/templates/document_new.html
+++ b/templates/document_new.html
@@ -21,18 +21,19 @@
         <input type="text" id="state" placeholder="State" value="{{document.customer_state}}" onchange="recalc()"><br>
         <input type="text" id="country" placeholder="DE" value="{{document.customer_country}}" onchange="recalc()">
       </div>
-      
+
       <div id="meta">
         <select id="kind" onchange="recalc()">
           <option value="invoice" selected>Invoice</option>
           <option value="quote">Quote</option>
           <option value="refund">Refund</option>
-	  <option value="delivery_note">Delivery Note</option><br>
-        </select> ID: <input type="text" id="id" placeholder="automatic"><br>
-        </select> Serial ID: <input type="text" id="serial_id" placeholder="automatic"><br>
-        <span>Replaces ID:</span> <input type="text" id="replaces_id" onchange="recalc()"><br>
-        <span>Date:</span> <input type="text" id="idate" value="{{document.doc_date}}" onchange="recalc()"><br>
-        <span>Order ID:</span> <input type="text" id="ordernum" onchange="recalc()"><br>
+          <option value="delivery_note">Delivery Note</option>
+        </select><br>
+        <label for="id">ID: </label><input type="text" id="id" placeholder="automatic"><br>
+        <label for="serial_id">Serial ID: </label><input type="text" id="serial_id" placeholder="automatic"><br>
+        <label for="replaces_id">Replaces ID:</label> <input type="text" id="replaces_id" onchange="recalc()"><br>
+        <label for="idate">Date:</label> <input type="text" id="idate" value="{{document.doc_date}}" onchange="recalc()"><br>
+        <label for="ordernum">Order ID:</label> <input type="text" id="ordernum" onchange="recalc()"><br>
         <select id="payment-method" onchange="recalc()">
           <option value="sepa" selected>SEPA</option>
           <option value="paypal">paypal (paid)</option>
@@ -115,15 +116,15 @@
     "EU7": 0.07,
     "NONEU0": 0
   }
-  
+
   function recalc() {
     var netTotal = 0.0
     numRows = 0
     var items = []
-    
+
     taxCode = document.getElementById("tax-code").value
     taxRate = TAX_RATES[taxCode]
-    
+
     while (true) {
       var key = "position-"+(numRows+1)
       var row = document.getElementById(key)
@@ -135,11 +136,11 @@
         var amountEl = document.getElementById(key+"-amount")
         var priceEl = document.getElementById(key+"-price")
         var sumEl = document.getElementById(key+"-sum")
-        
+
         var sum = (amountEl.value * priceEl.value).toFixed(2)
         sumEl.innerHTML = sum
         netTotal += parseFloat(sum)
-        
+
         items.push({
           sku: skuEl.value,
           title: titleEl.value,
@@ -152,12 +153,12 @@
         break
       }
     }
-    
+
     var netTotalEl = document.getElementById("total-net")
     var grandTotalEl = document.getElementById("total-grand")
     var taxTotalEl = document.getElementById("total-tax")
     var inclVAT = document.getElementById("incl-vat").checked
-    
+
     if (inclVAT) {
       var tax = ((netTotal/(1+taxRate)) * taxRate)
       var grandTotal = netTotal
@@ -166,13 +167,13 @@
       var tax = (netTotal * taxRate)
       var grandTotal = netTotal+tax
     }
-    
+
     taxTotalEl.innerHTML = tax.toFixed(2)
     grandTotalEl.innerHTML = grandTotal.toFixed(2)
     netTotalEl.innerHTML = netTotal.toFixed(2)
-    
+
     var paymentMethod = document.getElementById("payment-method").value
-    
+
     bookRow = {
       id: document.getElementById("id").value,
       serial_id: document.getElementById("serial_id").value,
@@ -200,10 +201,10 @@
       updated_at: new Date()  // FIXME
     }
   }
-  
+
   function addRow() {
     recalc()
-    
+
     var tbody = document.getElementById("positions")
     var template = document.getElementById("position-1")
     var id = numRows+1
@@ -213,17 +214,17 @@
     newRow.children[0].innerHTML = id
     tbody.appendChild(newRow)
   }
-  
+
   function deleteRow() {
     recalc()
-    
+
     var row = document.getElementById("position-"+(numRows))
     if (row && numRows > 1) row.remove()
   }
-  
+
   function finalize() {
     recalc()
-    
+
     var url = "/documents.json"
     var xhr = new XMLHttpRequest()
     xhr.onreadystatechange = function() {

--- a/templates/document_new.html
+++ b/templates/document_new.html
@@ -41,10 +41,10 @@
           {% endfor %}
         </select>
         <select id="tax-code" onchange="recalc()">
-          <option value="EU16" selected>EU 16%</option>
-          <option value="EU19">EU 19%</option>
-          <option value="EU7">EU 7%</option>
-          <option value="NONEU0">0%</option>
+          <option value="" selected>Tax Rate</option>
+          {% for rate in tax_rates %}
+            <option value="{{rate}}">{{rate}}</option>
+          {% endfor %}
         </select>
         <label><input type="checkbox" id="incl-vat" value="1" onchange="recalc()"> incl. VAT</label>
       </div>


### PR DESCRIPTION
This PR changes the `document_new` template to use select options dynamically generated from the `mntconfig.toml` file.

Both `tax_rates` and `invoice_payment_terms` use these dynamic options. This is a good thing, because the application is using the values passed to it to look up information in the toml file. An additional benefit is that when new rates or terms are added, they only need to be put in one place.

Not strictly required for this PR, but I did clean up the markup a little in preparation for this. There was a lot of white space, an extra closing tag, plus some missing labels.